### PR TITLE
Add some error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,17 @@ Usage:
 `vackup load IMAGE VOLUME`
   Copies /volume-data contents from an image to a volume
 
+## Error conditions
+
+If any of the commands fail, the script will check to see if a `VACKUP_FAILURE_SCRIPT` environment variable is set.  If so it will run it and pass the line number the error happened on and the exit code from the failed command.  Eg,
+```sh
+# /opt/bin/vackup-failed.sh
+LINE_NUMBER=$1
+EXIT_CODE=$2
+send_slack_webhook "Vackup failed on line number ${LINE_NUMBER} with exit code ${EXIT_CODE}!"
+```
+```
+export VACKUP_FAILURE_SCRIPT=/opt/bin/vackup-failed.sh
+./vackup export ......
+```
+

--- a/vackup
+++ b/vackup
@@ -3,6 +3,8 @@
 # Easily tar up a volume on a local (or remote) engine
 # Inspired by CLIP from Lukasz Lach
 
+set -Eeo pipefail
+
 usage() {
 cat <<EOF
 

--- a/vackup
+++ b/vackup
@@ -5,6 +5,16 @@
 
 set -Eeo pipefail
 
+handle_error() {
+  exit_code=$?
+  if [ -n "${VACKUP_FAILURE_SCRIPT}" ]; then
+    /bin/bash "${VACKUP_FAILURE_SCRIPT}" $1 $exit_code
+  fi
+  exit $exit_code
+}
+
+trap 'handle_error $LINENO' ERR
+
 usage() {
 cat <<EOF
 


### PR DESCRIPTION
Added the usual bash flags for exiting on errors.  Also a 2nd commit (and 3rd for the docs as I forgot.... docs, always an afterthought...) to add an error trap to optionally run a script if the vackup run fails.

Oh - and I also realised I changed the way `usage()` gets called and meant to do that in a separate PR.  Just a minor tidy though as it was triggering my OCD ;-)