### PR TITLE
zstd, xz, bzip2 compression support

### DIFF
--- a/vackup
+++ b/vackup
@@ -43,6 +43,11 @@ vackup load IMAGE VOLUME
 EOF
 }
 
+msg() {  # args: exit_code msg
+    printf >&2 '%s\n' "$2"
+    return "$1"
+}
+
 if [ -z "$1" ] || [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
     usage
     exit 0
@@ -58,8 +63,7 @@ detect_compression() {  # args: filename (de)compress-flag
         (*.xz)   VACKUP_COMPRESS=xz ;;
         (*.txz)  VACKUP_COMPRESS=xz ;;
         (*)
-          echo "Error: unknown extension ${1##*.}"
-          exit 1
+          msg 1 "Error: unknown extension ${1##*.}"
           ;;
     esac
     [ "$VACKUP_COMPRESS" = cat ] || VACKUP_COMPRESS="$VACKUP_COMPRESS $2"
@@ -71,21 +75,17 @@ cmd_export() {
 
     detect_compression "$FILE_NAME" -c
     if [ "${VACKUP_COMPRESS%% *}" = xz ]; then
-        echo 'Error: .tar.xz export not supported'
-        exit 1
+        msg 1 'Error: .tar.xz export not supported'
     fi
 
     if [ -z "$VOLUME_NAME" ] || [ -z "$FILE_NAME" ]; then
         usage
-        echo >&2
-        echo "Error: Not enough arguments"
-        exit 1
+        msg 1 "Error: Not enough arguments"
     fi
 
     if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME" >/dev/null 2>&1;
     then
-        echo "Error: Volume $VOLUME_NAME does not exist"
-        exit 1
+        msg 1 "Error: Volume $VOLUME_NAME does not exist"
     fi
 
 # TODO: check if file exists on host, if it does
@@ -100,11 +100,10 @@ cmd_export() {
       busybox \
       sh -c 'tar -cvf - /vackup-volume | $VACKUP_COMPRESS >/vackup/"$FILE_NAME"'
     then
-        echo "Error: Failed to start busybox backup container"
-        exit 1
+        msg 1 "Error: Failed to start busybox backup container"
     fi
 
-    echo "Successfully tar'ed volume $VOLUME_NAME into file $FILE_NAME"
+    msg 0 "Successfully tar'ed volume $VOLUME_NAME into file $FILE_NAME"
 }
 
 cmd_import() {
@@ -114,14 +113,13 @@ cmd_import() {
     detect_compression "$FILE_NAME" -d
 
     if [ -z "$VOLUME_NAME" ] || [ -z "$FILE_NAME" ]; then
-        echo "Error: Not enough arguments"
         usage
-        exit 1
+        msg 1 "Error: Not enough arguments"
     fi
 
     if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME" >/dev/null 2>&1;
     then
-        echo "Error: Volume $VOLUME_NAME does not exist"
+        msg 0 "Error: Volume $VOLUME_NAME does not exist"
         docker volume create "$VOLUME_NAME"
     fi
 
@@ -137,11 +135,10 @@ cmd_import() {
       busybox \
       sh -c '$VACKUP_COMPRESS </vackup/"$FILE_NAME" | tar >&2 -xvf - -C /'
     then
-        echo "Error: Failed to start busybox container"
-        exit 1
+        msg 1 "Error: Failed to start busybox container"
     fi
 
-    echo "Successfully unpacked $FILE_NAME into volume $VOLUME_NAME"
+    msg 0 "Successfully unpacked $FILE_NAME into volume $VOLUME_NAME"
 }
 
 cmd_save() {
@@ -149,15 +146,13 @@ cmd_save() {
     IMAGE_NAME=$3
 
     if [ -z "$VOLUME_NAME" ] || [ -z "$IMAGE_NAME" ]; then
-        echo "Error: Not enough arguments"
         usage
-        exit 1
+        msg 1 "Error: Not enough arguments"
     fi
 
     if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME"; 
     then
-        echo "Error: Volume $VOLUME_NAME does not exist"
-        exit 1
+        msg 1 "Error: Volume $VOLUME_NAME does not exist"
     fi
 
     if ! docker run \
@@ -165,8 +160,7 @@ cmd_save() {
       busybox \
       cp -Rp /mount-volume/. /volume-data/;
     then
-        echo "Error: Failed to start busybox container"
-        exit 1
+        msg 1 "Error: Failed to start busybox container"
     fi
 
     CONTAINER_ID=$(docker ps -lq)
@@ -175,7 +169,7 @@ cmd_save() {
 
     docker container rm "$CONTAINER_ID"
 
-    echo "Successfully copied volume $VOLUME_NAME into image $IMAGE_NAME, under /volume-data"
+    msg 0 "Successfully copied volume $VOLUME_NAME into image $IMAGE_NAME, under /volume-data"
 }
 
 cmd_load() {
@@ -183,14 +177,13 @@ cmd_load() {
     VOLUME_NAME=$3
 
     if [ -z "$VOLUME_NAME" ] || [ -z "$IMAGE_NAME" ]; then
-        echo "Error: Not enough arguments"
         usage
-        exit 1
+        msg 1 "Error: Not enough arguments"
     fi
 
     if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME"; 
     then
-      echo "Volume $VOLUME_NAME does not exist, creating..."
+      msg 0 "Volume $VOLUME_NAME does not exist, creating..."
       docker volume create "$VOLUME_NAME"
     fi
 
@@ -199,11 +192,10 @@ cmd_load() {
       "$IMAGE_NAME" \
       cp -Rp /volume-data/. /mount-volume/; 
     then
-        echo "Error: Failed to start container from $IMAGE_NAME"
-        exit 1
+        msg 1 "Error: Failed to start container from $IMAGE_NAME"
     fi
 
-    echo "Successfully copied /volume-data from $IMAGE_NAME into volume $VOLUME_NAME"
+    msg 0 "Successfully copied /volume-data from $IMAGE_NAME into volume $VOLUME_NAME"
 }
 
 COMMAND=$1

--- a/vackup
+++ b/vackup
@@ -34,7 +34,6 @@ vackup export VOLUME FILE
 
 vackup import FILE VOLUME
   Extract a tarball into a volume.
-  zstd decompression is not available.
 
 vackup save VOLUME IMAGE
   Copy volume contents to the /volume-data directory of a busybox image.
@@ -72,6 +71,8 @@ detect_compression() {  # args: filename (de)compress-flag
           msg 1 "Error: unknown extension ${1##*.}"
           ;;
     esac
+    command -v "$VACKUP_COMPRESS" >/dev/null ||
+      msg 1 "Error: $VACKUP_COMPRESS not available on host"
     [ "$VACKUP_COMPRESS" = cat ] || VACKUP_COMPRESS="$VACKUP_COMPRESS $2"
 }
 
@@ -85,8 +86,6 @@ cmd_export() {
     FILE_NAME=$3
 
     detect_compression "$FILE_NAME" -c
-    command -v "${VACKUP_COMPRESS%% *}" >/dev/null ||
-      msg 1 "Error: ${VACKUP_COMPRESS%% *} not available on host"
 
     if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME" >/dev/null 2>&1
     then
@@ -117,9 +116,6 @@ cmd_import() {
     VOLUME_NAME=$3
 
     detect_compression "$FILE_NAME" -d
-    if [ "${VACKUP_COMPRESS%% *}" = zstd ]; then
-        msg 1 'Error: zstd import not supported'
-    fi
 
     if [ ! -r "$FILE_NAME" ]; then
         msg 1 "Error: Cannot open \"$FILE_NAME\""
@@ -131,18 +127,11 @@ cmd_import() {
         docker volume create "$VOLUME_NAME"
     fi
 
-# TODO: check if file exists on host, if it does
-# create a option for overwrite and check if that's set
-# TODO: if FILE_NAME starts with / we need to error out
-# unless we can translate full file paths
-
-    if ! docker run --rm \
-      -e "FILE_NAME=$FILE_NAME" -e "VACKUP_COMPRESS=$VACKUP_COMPRESS" \
+    set -- docker run --rm -i \
       -v "$VOLUME_NAME":/vackup-volume \
-      -v "$(pwd)":/vackup \
       busybox \
-      sh -c '$VACKUP_COMPRESS </vackup/"$FILE_NAME" | tar >&2 -xvf - -C /'
-    then
+      tar -xvf - -C /
+    if ! $VACKUP_COMPRESS <"$FILE_NAME" | "$@" >&2; then
         msg 1 "Error: Failed to start busybox container"
     fi
 

--- a/vackup
+++ b/vackup
@@ -26,15 +26,15 @@ export/import copies files between a host tarball and a volume. For making
 save/load copies files between an image and a volume. For when you want to use
   image registries as a way to push/pull volume data.
 
-Usage: vackup COMMAND [ARG..]
-FILE args must have known suffixes: { .tar[.{ gz | bz2 | xz }] | .tgz | .txz }
+Usage: vackup COMMAND [ARG..]; FILE args must have known suffixes:
+  FILE = .{ tar[.{ gz | bz2 | xz | zst[d] }] | tgz | txz }
 
 vackup export VOLUME FILE
   Create a (compressed) tarball in current directory from a volume.
-  xz compression is not available.
 
 vackup import FILE VOLUME
   Extract a tarball into a volume.
+  zstd decompression is not available.
 
 vackup save VOLUME IMAGE
   Copy volume contents to the /volume-data directory of a busybox image.
@@ -66,6 +66,8 @@ detect_compression() {  # args: filename (de)compress-flag
         (*.bz2)  VACKUP_COMPRESS=bzip2 ;;
         (*.xz)   VACKUP_COMPRESS=xz ;;
         (*.txz)  VACKUP_COMPRESS=xz ;;
+        (*.zst)  VACKUP_COMPRESS=zstd ;;
+        (*.zstd) VACKUP_COMPRESS=zstd ;;
         (*)
           msg 1 "Error: unknown extension ${1##*.}"
           ;;
@@ -83,9 +85,8 @@ cmd_export() {
     FILE_NAME=$3
 
     detect_compression "$FILE_NAME" -c
-    if [ "${VACKUP_COMPRESS%% *}" = xz ]; then
-        msg 1 'Error: .tar.xz export not supported'
-    fi
+    command -v "${VACKUP_COMPRESS%% *}" >/dev/null ||
+      msg 1 "Error: ${VACKUP_COMPRESS%% *} not available on host"
 
     if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME" >/dev/null 2>&1
     then
@@ -94,16 +95,12 @@ cmd_export() {
 
 # TODO: check if file exists on host, if it does
 # create a option for overwrite and check if that's set
-# TODO: if FILE_NAME starts with / we need to error out
-# unless we can translate full file paths
 
-    if ! docker run --rm \
-      -e "FILE_NAME=$FILE_NAME" -e "VACKUP_COMPRESS=$VACKUP_COMPRESS" \
+    set -- docker run --rm \
       -v "$VOLUME_NAME":/vackup-volume \
-      -v "$(pwd)":/vackup \
       busybox \
-      sh -c 'tar -cvf - /vackup-volume | $VACKUP_COMPRESS >/vackup/"$FILE_NAME"'
-    then
+      tar -cvf - /vackup-volume  # tar -vf - outputs list to stderr
+    if ! "$@" | $VACKUP_COMPRESS >"$FILE_NAME"; then
         msg 1 "Error: Failed to start busybox backup container"
     fi
 
@@ -120,6 +117,9 @@ cmd_import() {
     VOLUME_NAME=$3
 
     detect_compression "$FILE_NAME" -d
+    if [ "${VACKUP_COMPRESS%% *}" = zstd ]; then
+        msg 1 'Error: zstd import not supported'
+    fi
 
     if [ ! -r "$FILE_NAME" ]; then
         msg 1 "Error: Cannot open \"$FILE_NAME\""

--- a/vackup
+++ b/vackup
@@ -117,6 +117,10 @@ cmd_import() {
         msg 1 "Error: Not enough arguments"
     fi
 
+    if [ ! -r "$FILE_NAME" ]; then
+        msg 1 "Error: Cannot open \"$FILE_NAME\""
+    fi
+
     if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME" >/dev/null 2>&1
     then
         msg 0 "Error: Volume $VOLUME_NAME does not exist"

--- a/vackup
+++ b/vackup
@@ -51,13 +51,13 @@ fi
 cmd_export() {
     VOLUME_NAME="$2"
     FILE_NAME="$3"
-    
+
     if [ -z "$VOLUME_NAME" ] || [ -z "$FILE_NAME" ]; then
         echo "Error: Not enough arguments"
         usage
         exit 1
     fi
-    
+
     if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME";
     then
         echo "Error: Volume $VOLUME_NAME does not exist"
@@ -85,13 +85,13 @@ cmd_export() {
 cmd_import() {
     FILE_NAME="$2"
     VOLUME_NAME="$3"
-    
+
     if [ -z "$VOLUME_NAME" ] || [ -z "$FILE_NAME" ]; then
         echo "Error: Not enough arguments"
         usage
         exit 1
     fi
-    
+
     if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME";
     then
         echo "Error: Volume $VOLUME_NAME does not exist"
@@ -146,14 +146,14 @@ cmd_save() {
     docker commit -m "saving volume $VOLUME_NAME to /volume-data" "$CONTAINER_ID" "$IMAGE_NAME"
 
     docker container rm "$CONTAINER_ID"
-  
+
     echo "Successfully copied volume $VOLUME_NAME into image $IMAGE_NAME, under /volume-data"
 }
 
 cmd_load() {
     IMAGE_NAME="$2"
     VOLUME_NAME="$3"
-    
+
     if [ -z "$VOLUME_NAME" ] || [ -z "$IMAGE_NAME" ]; then
         echo "Error: Not enough arguments"
         usage
@@ -165,7 +165,7 @@ cmd_load() {
       echo "Volume $VOLUME_NAME does not exist, creating..."
       docker volume create "$VOLUME_NAME"
     fi
-    
+
     if ! docker run --rm \
       -v "$VOLUME_NAME":/mount-volume \
       "$IMAGE_NAME" \

--- a/vackup
+++ b/vackup
@@ -23,10 +23,10 @@ cat <<EOF
 export/import copies files between a host tarball and a volume. For making
   volume backups and restores.
 
-save/load copies files between an image and a volume. For when you want to use 
+save/load copies files between an image and a volume. For when you want to use
   image registries as a way to push/pull volume data.
 
-Usage: 
+Usage:
 
 vackup export VOLUME FILE
   Creates a gzip'ed tarball in current directory from a volume
@@ -83,7 +83,7 @@ cmd_export() {
         msg 1 "Error: Not enough arguments"
     fi
 
-    if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME" >/dev/null 2>&1;
+    if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME" >/dev/null 2>&1
     then
         msg 1 "Error: Volume $VOLUME_NAME does not exist"
     fi
@@ -117,7 +117,7 @@ cmd_import() {
         msg 1 "Error: Not enough arguments"
     fi
 
-    if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME" >/dev/null 2>&1;
+    if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME" >/dev/null 2>&1
     then
         msg 0 "Error: Volume $VOLUME_NAME does not exist"
         docker volume create "$VOLUME_NAME"
@@ -126,7 +126,7 @@ cmd_import() {
 # TODO: check if file exists on host, if it does
 # create a option for overwrite and check if that's set
 # TODO: if FILE_NAME starts with / we need to error out
-# unless we can translate full file paths    
+# unless we can translate full file paths
 
     if ! docker run --rm \
       -e "FILE_NAME=$FILE_NAME" -e "VACKUP_COMPRESS=$VACKUP_COMPRESS" \
@@ -150,7 +150,7 @@ cmd_save() {
         msg 1 "Error: Not enough arguments"
     fi
 
-    if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME"; 
+    if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME"
     then
         msg 1 "Error: Volume $VOLUME_NAME does not exist"
     fi
@@ -158,7 +158,7 @@ cmd_save() {
     if ! docker run \
       -v "$VOLUME_NAME":/mount-volume \
       busybox \
-      cp -Rp /mount-volume/. /volume-data/;
+      cp -Rp /mount-volume/. /volume-data/
     then
         msg 1 "Error: Failed to start busybox container"
     fi
@@ -181,7 +181,7 @@ cmd_load() {
         msg 1 "Error: Not enough arguments"
     fi
 
-    if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME"; 
+    if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME"
     then
       msg 0 "Volume $VOLUME_NAME does not exist, creating..."
       docker volume create "$VOLUME_NAME"
@@ -190,7 +190,7 @@ cmd_load() {
     if ! docker run --rm \
       -v "$VOLUME_NAME":/mount-volume \
       "$IMAGE_NAME" \
-      cp -Rp /volume-data/. /mount-volume/; 
+      cp -Rp /volume-data/. /mount-volume/
     then
         msg 1 "Error: Failed to start container from $IMAGE_NAME"
     fi

--- a/vackup
+++ b/vackup
@@ -58,7 +58,7 @@ cmd_export() {
         exit 1
     fi
 
-    if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME";
+    if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME" >/dev/null 2>&1;
     then
         echo "Error: Volume $VOLUME_NAME does not exist"
         exit 1
@@ -92,7 +92,7 @@ cmd_import() {
         exit 1
     fi
 
-    if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME";
+    if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME" >/dev/null 2>&1;
     then
         echo "Error: Volume $VOLUME_NAME does not exist"
         docker volume create "$VOLUME_NAME"

--- a/vackup
+++ b/vackup
@@ -49,8 +49,8 @@ if [ -z "$1" ] || [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
 fi
 
 cmd_export() {
-    VOLUME_NAME="$2"
-    FILE_NAME="$3"
+    VOLUME_NAME=$2
+    FILE_NAME=$3
 
     if [ -z "$VOLUME_NAME" ] || [ -z "$FILE_NAME" ]; then
         echo "Error: Not enough arguments"
@@ -83,8 +83,8 @@ cmd_export() {
 }
 
 cmd_import() {
-    FILE_NAME="$2"
-    VOLUME_NAME="$3"
+    FILE_NAME=$2
+    VOLUME_NAME=$3
 
     if [ -z "$VOLUME_NAME" ] || [ -z "$FILE_NAME" ]; then
         echo "Error: Not enough arguments"
@@ -117,8 +117,8 @@ cmd_import() {
 }
 
 cmd_save() {
-    VOLUME_NAME="$2"
-    IMAGE_NAME="$3"
+    VOLUME_NAME=$2
+    IMAGE_NAME=$3
 
     if [ -z "$VOLUME_NAME" ] || [ -z "$IMAGE_NAME" ]; then
         echo "Error: Not enough arguments"
@@ -151,8 +151,8 @@ cmd_save() {
 }
 
 cmd_load() {
-    IMAGE_NAME="$2"
-    VOLUME_NAME="$3"
+    IMAGE_NAME=$2
+    VOLUME_NAME=$3
 
     if [ -z "$VOLUME_NAME" ] || [ -z "$IMAGE_NAME" ]; then
         echo "Error: Not enough arguments"
@@ -178,7 +178,7 @@ cmd_load() {
     echo "Successfully copied /volume-data from $IMAGE_NAME into volume $VOLUME_NAME"
 }
 
-COMMAND="$1"
+COMMAND=$1
 case "$COMMAND" in
   export) cmd_export "$@" ;;
   import) cmd_import "$@" ;;

--- a/vackup
+++ b/vackup
@@ -180,10 +180,10 @@ cmd_load() {
 
 COMMAND=$1
 case "$COMMAND" in
-  export) cmd_export "$@" ;;
-  import) cmd_import "$@" ;;
-  save) cmd_save "$@" ;;
-  load) cmd_load "$@" ;;
+  (export) cmd_export "$@" ;;
+  (import) cmd_import "$@" ;;
+  (save) cmd_save "$@" ;;
+  (load) cmd_load "$@" ;;
 esac
 
 exit 0

--- a/vackup
+++ b/vackup
@@ -76,8 +76,9 @@ cmd_export() {
     fi
 
     if [ -z "$VOLUME_NAME" ] || [ -z "$FILE_NAME" ]; then
-        echo "Error: Not enough arguments"
         usage
+        echo >&2
+        echo "Error: Not enough arguments"
         exit 1
     fi
 

--- a/vackup
+++ b/vackup
@@ -16,7 +16,7 @@ handle_error() {
 trap 'handle_error $LINENO' ERR
 
 usage() {
-cat <<EOF
+cat >&2 <<"EOF"
 
 "Docker Volume Backup". Replicates image management commands for volumes.
 
@@ -26,19 +26,23 @@ export/import copies files between a host tarball and a volume. For making
 save/load copies files between an image and a volume. For when you want to use
   image registries as a way to push/pull volume data.
 
-Usage:
+Usage: vackup COMMAND [ARG..]
+FILE args must have known suffixes: { .tar[.{ gz | bz2 | xz }] | .tgz | .txz }
 
 vackup export VOLUME FILE
-  Creates a gzip'ed tarball in current directory from a volume
+  Create a (compressed) tarball in current directory from a volume.
+  xz compression is not available.
 
 vackup import FILE VOLUME
-  Extracts a gzip'ed tarball into a volume
+  Extract a tarball into a volume.
 
 vackup save VOLUME IMAGE
-  Copies the volume contents to a busybox image in the /volume-data directory
+  Copy volume contents to the /volume-data directory of a busybox image.
 
 vackup load IMAGE VOLUME
-  Copies /volume-data contents from an image to a volume
+  Copy /volume-data contents from an image to a volume.
+
+Environment: $VACKUP_FAILURE_SCRIPT, $VACKUP_COMPRESS
 
 EOF
 }
@@ -48,8 +52,8 @@ msg() {  # args: exit_code msg
     return "$1"
 }
 
-if [ -z "$1" ] || [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
-    usage
+if [ $# = 0 ] || [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
+    usage 2>&1  # print usage to stdout on request (unlike on error)
     exit 0
 fi
 
@@ -70,17 +74,17 @@ detect_compression() {  # args: filename (de)compress-flag
 }
 
 cmd_export() {
+    if [ $# != 3 ]; then
+        usage
+        msg 1 "Error: wrong number of arguments"
+    fi
+
     VOLUME_NAME=$2
     FILE_NAME=$3
 
     detect_compression "$FILE_NAME" -c
     if [ "${VACKUP_COMPRESS%% *}" = xz ]; then
         msg 1 'Error: .tar.xz export not supported'
-    fi
-
-    if [ -z "$VOLUME_NAME" ] || [ -z "$FILE_NAME" ]; then
-        usage
-        msg 1 "Error: Not enough arguments"
     fi
 
     if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME" >/dev/null 2>&1
@@ -107,15 +111,15 @@ cmd_export() {
 }
 
 cmd_import() {
+    if [ $# != 3 ]; then
+        usage
+        msg 1 "Error: wrong number of arguments"
+    fi
+
     FILE_NAME=$2
     VOLUME_NAME=$3
 
     detect_compression "$FILE_NAME" -d
-
-    if [ -z "$VOLUME_NAME" ] || [ -z "$FILE_NAME" ]; then
-        usage
-        msg 1 "Error: Not enough arguments"
-    fi
 
     if [ ! -r "$FILE_NAME" ]; then
         msg 1 "Error: Cannot open \"$FILE_NAME\""
@@ -123,7 +127,7 @@ cmd_import() {
 
     if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME" >/dev/null 2>&1
     then
-        msg 0 "Error: Volume $VOLUME_NAME does not exist"
+        msg 0 "Warning: Volume $VOLUME_NAME does not exist, will be created"
         docker volume create "$VOLUME_NAME"
     fi
 
@@ -146,13 +150,13 @@ cmd_import() {
 }
 
 cmd_save() {
+    if [ $# != 3 ]; then
+        usage
+        msg 1 "Error: wrong number of arguments"
+    fi
+
     VOLUME_NAME=$2
     IMAGE_NAME=$3
-
-    if [ -z "$VOLUME_NAME" ] || [ -z "$IMAGE_NAME" ]; then
-        usage
-        msg 1 "Error: Not enough arguments"
-    fi
 
     if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME"
     then
@@ -177,13 +181,13 @@ cmd_save() {
 }
 
 cmd_load() {
+    if [ $# != 3 ]; then
+        usage
+        msg 1 "Error: wrong number of arguments"
+    fi
+
     IMAGE_NAME=$2
     VOLUME_NAME=$3
-
-    if [ -z "$VOLUME_NAME" ] || [ -z "$IMAGE_NAME" ]; then
-        usage
-        msg 1 "Error: Not enough arguments"
-    fi
 
     if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME"
     then
@@ -208,6 +212,10 @@ case "$COMMAND" in
   (import) cmd_import "$@" ;;
   (save) cmd_save "$@" ;;
   (load) cmd_load "$@" ;;
+  (*)
+      usage
+      msg 1 "Error: Unknown operation $COMMAND"
+      ;;
 esac
 
 exit 0

--- a/vackup
+++ b/vackup
@@ -48,9 +48,32 @@ if [ -z "$1" ] || [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
     exit 0
 fi
 
+detect_compression() {  # args: filename (de)compress-flag
+    [ -z ${VACKUP_COMPRESS:-} ] || return 0
+    case "$1" in
+        (*.tar)  VACKUP_COMPRESS=cat ;;
+        (*.gz)   VACKUP_COMPRESS=gzip ;;
+        (*.tgz)  VACKUP_COMPRESS=gzip ;;
+        (*.bz2)  VACKUP_COMPRESS=bzip2 ;;
+        (*.xz)   VACKUP_COMPRESS=xz ;;
+        (*.txz)  VACKUP_COMPRESS=xz ;;
+        (*)
+          echo "Error: unknown extension ${1##*.}"
+          exit 1
+          ;;
+    esac
+    [ "$VACKUP_COMPRESS" = cat ] || VACKUP_COMPRESS="$VACKUP_COMPRESS $2"
+}
+
 cmd_export() {
     VOLUME_NAME=$2
     FILE_NAME=$3
+
+    detect_compression "$FILE_NAME" -c
+    if [ "${VACKUP_COMPRESS%% *}" = xz ]; then
+        echo 'Error: .tar.xz export not supported'
+        exit 1
+    fi
 
     if [ -z "$VOLUME_NAME" ] || [ -z "$FILE_NAME" ]; then
         echo "Error: Not enough arguments"
@@ -70,10 +93,11 @@ cmd_export() {
 # unless we can translate full file paths
 
     if ! docker run --rm \
+      -e "FILE_NAME=$FILE_NAME" -e "VACKUP_COMPRESS=$VACKUP_COMPRESS" \
       -v "$VOLUME_NAME":/vackup-volume \
       -v "$(pwd)":/vackup \
       busybox \
-      tar -zcvf /vackup/"$FILE_NAME" /vackup-volume;
+      sh -c 'tar -cvf - /vackup-volume | $VACKUP_COMPRESS >/vackup/"$FILE_NAME"'
     then
         echo "Error: Failed to start busybox backup container"
         exit 1
@@ -85,6 +109,8 @@ cmd_export() {
 cmd_import() {
     FILE_NAME=$2
     VOLUME_NAME=$3
+
+    detect_compression "$FILE_NAME" -d
 
     if [ -z "$VOLUME_NAME" ] || [ -z "$FILE_NAME" ]; then
         echo "Error: Not enough arguments"
@@ -104,10 +130,11 @@ cmd_import() {
 # unless we can translate full file paths    
 
     if ! docker run --rm \
+      -e "FILE_NAME=$FILE_NAME" -e "VACKUP_COMPRESS=$VACKUP_COMPRESS" \
       -v "$VOLUME_NAME":/vackup-volume \
       -v "$(pwd)":/vackup \
       busybox \
-      tar -xvzf /vackup/"$FILE_NAME" -C /; 
+      sh -c '$VACKUP_COMPRESS </vackup/"$FILE_NAME" | tar >&2 -xvf - -C /'
     then
         echo "Error: Failed to start busybox container"
         exit 1


### PR DESCRIPTION
I've added more (de)compression options for import / export. Compression is auto-detected from filename extensions, or can be specified in `VACKUP_COMPRESS`.

Other changes:
- (de)compression is performed on the host; the uncompressed tarball is piped into / out of the container
- `FILE` args can be full paths
- all messages go to stderr (in the future, perhaps `FILE` args could be `-` for stdin / stdout backup / restore)

The README would need to be updated as well.