### PR TITLE
prefer using `-o, --output` option with curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ Usage:
 Download the `vackup` file in this repository to your local machine in your shell path and make it executable.
 
 ```shell
-curl -sSL https://raw.githubusercontent.com/BretFisher/docker-vackup/main/vackup > /usr/local/bin/vackup
-chmod +x /usr/local/bin/vackup
+sudo curl -sSL https://raw.githubusercontent.com/BretFisher/docker-vackup/main/vackup -o /usr/local/bin/vackup && sudo chmod +x /usr/local/bin/vackup
 ```
 
 ## Error conditions


### PR DESCRIPTION
This also allows the use of `sudo` with curl, since using sudo and the redirection operator causes a permission error:
 `-bash: /usr/local/bin/vackup: Permission denied`