### PR TITLE
print error and exit if file can't be opened during import

### DIFF
--- a/vackup
+++ b/vackup
@@ -91,7 +91,12 @@ cmd_import() {
         usage
         exit 1
     fi
-    
+
+    if [ ! -r "$FILE_NAME" ]; then
+        echo "Error: Could not find or open tar file $FILE_NAME"
+        exit 1
+    fi
+
     if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME";
     then
         echo "Error: Volume $VOLUME_NAME does not exist"

--- a/vackup
+++ b/vackup
@@ -103,8 +103,6 @@ cmd_import() {
         docker volume create "$VOLUME_NAME"
     fi
 
-# TODO: check if file exists on host, if it does
-# create a option for overwrite and check if that's set
 # TODO: if FILE_NAME starts with / we need to error out
 # unless we can translate full file paths    
 

--- a/vackup
+++ b/vackup
@@ -97,6 +97,11 @@ cmd_import() {
         exit 1
     fi
 
+    if [ -d "$FILE_NAME" ]; then
+        echo "Error: $FILE_NAME is a directory"
+        exit 1
+    fi
+
     if ! docker volume inspect --format '{{.Name}}' "$VOLUME_NAME";
     then
         echo "Error: Volume $VOLUME_NAME does not exist"


### PR DESCRIPTION
E.g.

```
$ ls
vackup
$ ./vackup import mosquitto_config.tar.gz mosquitto_config
Error: Could not find or open tar file mosquitto_config.tar.gz
```