### PR TITLE
Don't use Bash case fallthrough

### DIFF
--- a/vackup
+++ b/vackup
@@ -83,7 +83,6 @@ fulldirname() {
 
   case "$DIRECTORY" in
     /*) ;;
-    .*) ;& # fallthrough
     *) DIRECTORY="$(pwd)/$DIRECTORY" ;;
   esac
   DIRECTORY=$(readlink -m "$DIRECTORY")


### PR DESCRIPTION
The feature was added in Bash 4.0, however, according to @markaltmann, some Mac systems still use Bash 3.x

The feature was used only for expressiveness, the line using it is completely optional (since the case it falls through to is `*`, aka a catch all), thus it can be safely removed without changing the logic.