### PR TITLE
Use the -f flag instead of -m flag for readlink

### DIFF
--- a/vackup
+++ b/vackup
@@ -86,7 +86,7 @@ fulldirname() {
     .*) ;& # fallthrough
     *) DIRECTORY="$(pwd)/$DIRECTORY" ;;
   esac
-  DIRECTORY=$(readlink -m "$DIRECTORY")
+  DIRECTORY=$(readlink -f "$DIRECTORY")
 
   echo "$DIRECTORY"
 }


### PR DESCRIPTION
The `-m` flag isn't as portable as I thought. According to [Mark Altmann](https://github.com/BretFisher/docker-vackup/pull/24#issuecomment-2498396444), the `-m` is not available on older Mac systems, and may not be available on [BSD](https://man.freebsd.org/cgi/man.cgi?query=readlink&sektion=1).

The `-f` flag should be more universal.

I'll test to make sure all things work as they did, until then I'll leave this as a draft.

Edit: Here's a list of things I tested:
 - Normal paths (not containing any links) work as before, so no issues here.
 - If the destination path (e.g. `test4/mosquitto_config.tar.gz`) contains a link to itself (e.g. `test4 -> test4`), `readlink` with `-m` returns the path to the link (e.g. `/home/user/directory/test4`), while with `-f` it returns an empty string. Either case results in a Docker error, though different ones.
 - Paths containing 1 valid link work as intended (e.g. 'test5 -> test3', `test5/mosquitto_config.tar.gz`, both `-m` and `-f` correctly resolve to `/home/user/directory/test3`)
 - Using paths with last link pointing to a nonexistent directory works in both cases (e.g. running `rm -rf test3` in the above case before exporting), though this will create that missing directory
 - Paths with multiple links work the same in both cases (e.g. `test6 -> test6.1` and `test6.1 -> test3` when destination is `test6/bitwarden_data.tar.gz`)
 - If the destination contains a link to a nonexistent directory and the target is a subdirectory, `-m` works but `-f` fails (e.g. `test7 -> test3` and destination is `test3/test/mosquitto_config.tar.gz`, but `test3` doesnt exist (`rm -rf test3`), then `-m` returns the correct path `/home/user/directory/test3/test`, but `-f` return an empty string)

Overall, the main difference, from what I can tell, is that `-f` will faill if a link in the middle of the destination path points to an invalid object, wheres `-m` works, which was the reason of using it in the first place:

> -m, --canonicalize-missing
>        canonicalize by following every symlink in every component of the given name recursively, _**without requirements on components existence**_

If we use `-f`, might be worth erroring out with a better message when `readlink` returns an empty string. I'll add that if you agree with that.