### PR TITLE
Update bash reference

### DIFF
--- a/vackup
+++ b/vackup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Docker Volume File Backup and Restore Tool
 # Easily tar up a volume on a local (or remote) engine
 # Inspired by CLIP from Lukasz Lach


### PR DESCRIPTION
According to: https://stackoverflow.com/questions/16365130/what-is-the-difference-between-usr-bin-env-bash-and-usr-bin-bash

The idea is to use a user provided bash path and not only look a a predefined path (although it might be posix compliant etc...)

One reason of doing so is that the bundled bash on macOS is really old, but even if you use a more modern bash, it will not be picked up by this script. Other then calling it with the proper bash

Example macOS 14.7.1:

```bash
$ /bin/bash --version
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin23)
Copyright (C) 2007 Free Software Foundation, Inc.

$ which bash
/opt/homebrew/bin/bash
$ bash --version
GNU bash, Version 5.2.37(1)-release (aarch64-apple-darwin23.4.0)
Copyright (C) 2022 Free Software Foundation, Inc.
Lizenz GPLv3+: GNU GPL Version 3 oder jünger <http://gnu.org/licenses/gpl.html>
```