### PR TITLE
Don't error out if chown fails and avoid manually escaping quotes

### DIFF
--- a/vackup
+++ b/vackup
@@ -177,7 +177,7 @@ cmd_export() {
       -v "$VOLUME_NAME":/volume-data \
       -v "$DIRECTORY":/mount-volume \
       busybox \
-      /bin/sh -c 'tar -cvzf /mount-volume/'"'$FILE_NAME'"' -C /volume-data . && chown '"'${OWNER:-"$(id -u):$(id -g)"}'"' /mount-volume/'"'$FILE_NAME'";
+      /bin/sh -c 'tar -cvzf /mount-volume/'"'$FILE_NAME'"' -C /volume-data . && (chown '"'${OWNER:-"$(id -u):$(id -g)"}'"' /mount-volume/'"'$FILE_NAME'"' || echo 1>&2 "Warning: Failed to change ownership of the '"$FILE_NAME"' file")';
     then
         error 'Failed to start busybox backup container'
     fi

--- a/vackup
+++ b/vackup
@@ -174,10 +174,12 @@ cmd_export() {
     FILE_NAME=$(basename "$FILE_NAME")
 
     if ! docker run --rm \
+      -e FILE_NAME="$FILE_NAME" \
+      -e OWNER="${OWNER:-"$(id -u):$(id -g)"}" \
       -v "$VOLUME_NAME":/volume-data \
       -v "$DIRECTORY":/mount-volume \
       busybox \
-      /bin/sh -c 'tar -cvzf /mount-volume/'"'$FILE_NAME'"' -C /volume-data . && (chown '"'${OWNER:-"$(id -u):$(id -g)"}'"' /mount-volume/'"'$FILE_NAME'"' || echo 1>&2 "Warning: Failed to change ownership of the '"$FILE_NAME"' file")';
+      /bin/sh -c 'tar -cvzf /mount-volume/"$FILE_NAME" -C /volume-data . && (chown "$OWNER" /mount-volume/"$FILE_NAME" || echo 1>&2 "Warning: Failed to change ownership of the $FILE_NAME file")';
     then
         error 'Failed to start busybox backup container'
     fi


### PR DESCRIPTION
chown may fail when the destination file system doesn't support Unix ownership attributes. Since the success of `chown` isn't critical, if this happens, just print a warning and continue.

Fixes #37 

Demo:

- Before this PR:

  ```console
  $ sudo vackup export diun_data diun_data.tar.gz
  diun_data
  ./
  ./diun.db
  chown: /mount-volume/diun_data.tar.gz: Operation not permitted
  Error: Failed to start busybox backup container
  $ ls
  diun_data.tar.gz
  ```

- After this PR:

  ```console
  $ sudo vackup export diun_data diun_data.tar.gz
  diun_data
  ./
  ./diun.db
  chown: /mount-volume/diun_data.tar.gz: Operation not permitted
  Warning: Failed to change ownership of the diun_data.tar.gz file
  Successfully tar'ed volume diun_data into file diun_data.tar.gz
  $ ls
  diun_data.tar.gz
  ```

Edit: Added 2nd commit, which passes variables to the Docker container as environmental variables and expands them inside the container. This avoids manually escaping quotes, which may fail if the file name contains a single/double quote character.